### PR TITLE
Bugfix/examples content

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ you should use the folowing syntax, making sure there are no whitespaces at the 
 
 ### Specifying/Testing API Security ###
 
-Swagger allows for the specification of different security schemes and their applicability to operations in an API. 
-To leverage this in rswag, you define the schemes globally in _swagger_helper.rb_ and then use the "security" attribute at the operation level to specify which schemes, if any, are applicable to that operation. 
+Swagger allows for the specification of different security schemes and their applicability to operations in an API.
+To leverage this in rswag, you define the schemes globally in _swagger_helper.rb_ and then use the "security" attribute at the operation level to specify which schemes, if any, are applicable to that operation.
 Swagger supports :basic, :bearer, :apiKey and :oauth2 and :openIdConnect scheme types. See [the spec](https://swagger.io/docs/specification/authentication/) for more info, as this underwent major changes between Swagger 2.0 and Open API 3.0
 
 ```ruby
@@ -416,7 +416,7 @@ describe 'Blogs API' do
 end
 
 # example of documenting an endpoint that handles basic auth and api key based security
-describe 'Auth examples API' do 
+describe 'Auth examples API' do
   path '/auth-tests/basic-and-api-key' do
     post 'Authenticates with basic auth and api key' do
       tags 'Auth Tests'
@@ -437,11 +437,11 @@ describe 'Auth examples API' do
     end
   end
 end
- 
+
 
 ```
 
-__NOTE:__ Depending on the scheme types, you'll be required to assign a corresponding parameter value with each example. 
+__NOTE:__ Depending on the scheme types, you'll be required to assign a corresponding parameter value with each example.
 For example, :basic auth is required above and so the :Authorization (header) parameter must be set accordingly
 
 ## Configuration & Customization ##
@@ -479,9 +479,9 @@ rake rswag:specs:swaggerize PATTERN="spec/swagger/**/*_spec.rb"
 
 ### Referenced Parameters and Schema Definitions ###
 
-Swagger allows you to describe JSON structures inline with your operation descriptions OR as referenced globals. 
+Swagger allows you to describe JSON structures inline with your operation descriptions OR as referenced globals.
 For example, you might have a standard response structure for all failed operations.
-Again, this is a structure that changed since swagger 2.0. Notice the new "schemas" section for these. 
+Again, this is a structure that changed since swagger 2.0. Notice the new "schemas" section for these.
 Rather than repeating the schema in every operation spec, you can define it globally and provide a reference to it in each spec:
 
 ```ruby
@@ -549,7 +549,7 @@ end
 
 ### Response headers ###
 
-In Rswag, you could use `header` method inside the response block to specify header objects for this response. 
+In Rswag, you could use `header` method inside the response block to specify header objects for this response.
 Rswag will validate your response headers with those header objects and inject them into the generated swagger file:
 
 ```ruby
@@ -597,16 +597,20 @@ To enable examples generation from responses add callback above run_test! like:
 
 ```
 after do |example|
-  example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+  example.metadata[:response][:content] = {
+    'application/json' => {
+      example: JSON.parse(response.body, symbolize_names: true)
+    }
+  }
 end
 ```
 
 You need to disable --dry-run option for Rspec > 3
 
-<!-- This is now enabled by default in rswag. 
+<!-- This is now enabled by default in rswag.
 You need to set the ``` config.swagger_dry_run = false``` value in the spec/spec_helper.rb file.
 This is one of the more powerful features of rswag. When rswag runs your integration test suite via ```bundle exec rspec```, it will capture the request and response bodies and output those values in the examples section.
-These integration tests are usually written with ```let``` variables for post body parameters, and since its an integration test the service is returning actual values. 
+These integration tests are usually written with ```let``` variables for post body parameters, and since its an integration test the service is returning actual values.
 We might as well re-use these values and embed them into the generated swagger to provide a more real world example for request/response examples. -->
 
 Add to config/environments/test.rb:
@@ -645,8 +649,8 @@ describe 'Blogs API', document: false do
 ```
 
 ##### rswag helper methods #####
-<!-- 
-There are some helper methods to help with documenting request bodies. 
+<!--
+There are some helper methods to help with documenting request bodies.
 ```ruby
 describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
   let(:api_key) { 'fake_key' }
@@ -682,7 +686,7 @@ describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       end
     end
   end
-end    
+end
 ```
 
 In the above example, we see methods ```request_body_json``` ```request_body_plain``` ```request_body_xml```.
@@ -692,7 +696,7 @@ and the examples: :blog which will create a named example "blog" under the "requ
 Again, documenting request response examples changed in Open API 3.0. The example above would generate a swagger.json snippet that looks like this:
 
 ```json
-        ... 
+        ...
         {"requestBody": {
           "required": true,
           "content": {
@@ -726,9 +730,9 @@ Again, documenting request response examples changed in Open API 3.0. The exampl
         }
 ```
 
-*NOTE:* for this example request body to work in the tests properly, you need to ``let`` a variable named *blog*. 
+*NOTE:* for this example request body to work in the tests properly, you need to ``let`` a variable named *blog*.
 The variable with the matching name (blog in this case) is eval-ed and captured to be placed in the examples section.
-This ```let``` value is used in the integration test to run the test AND captured and injected into the requestBody section. 
+This ```let``` value is used in the integration test to run the test AND captured and injected into the requestBody section.
 
 ##### rswag response examples #####
 
@@ -826,7 +830,7 @@ You can specify custom headers for serving your generated Swagger JSON. For exam
 ```ruby
 Rswag::Api.configure do |c|
   ...
-  
+
   c.swagger_headers = { 'Content-Type' => 'application/json; charset=UTF-8' }
 end
 ```
@@ -898,6 +902,5 @@ docker pull swaggerapi/swagger-editor
 ```
 docker run -d -p 80:8080 swaggerapi/swagger-editor
 ```
-This will run the swagger editor in the docker daemon and can be accessed 
+This will run the swagger editor in the docker daemon and can be accessed
 at ```http://localhost```. From here, you can use the UI to load the generated swagger.json to validate the output.
-

--- a/rswag-specs/lib/generators/rspec/templates/spec.rb
+++ b/rswag-specs/lib/generators/rspec/templates/spec.rb
@@ -19,7 +19,11 @@ RSpec.describe '<%= controller_path %>', type: :request do
 <%      end -%>
 
         after do |example|
-          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
         end
         run_test!
       end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -78,10 +78,6 @@ module Rswag
           end
       end
 
-      # example.metadata[:response][:content] = {
-      #   'application/json' => { example: json }
-      # }
-
       def run_test!(&block)
         # NOTE: rspec 2.x support
         if RSPEC_VERSION < 3

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -72,8 +72,15 @@ module Rswag
       def examples(example = nil)
         return super() if example.nil?
 
-        metadata[:response][:examples] = example
+        metadata[:response][:content] =
+          example.each_with_object({}) do |(mime, example_object), memo|
+            memo[mime] = { example: example_object }
+          end
       end
+
+      # example.metadata[:response][:content] = {
+      #   'application/json' => { example: json }
+      # }
 
       def run_test!(&block)
         # NOTE: rspec 2.x support

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -129,13 +129,13 @@ module Rswag
       end
 
       def upgrade_content!(mime_list, target_node)
-        target_node.merge!(content: {})
+        target_node[:content] ||= {}
         schema = target_node[:schema]
         return if mime_list.empty? || schema.nil?
 
         mime_list.each do |mime_type|
           # TODO upgrade to have content-type specific schema
-          target_node[:content][mime_type] = { schema: schema }
+          (target_node[:content][mime_type] ||= {}).merge!(schema: schema)
         end
       end
 

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -137,9 +137,10 @@ module Rswag
       end
 
       describe '#examples(example)' do
+        let(:mime) { 'application/json' }
         let(:json_example) do
           {
-            'application/json' => {
+            mime => {
               foo: 'bar'
             }
           }
@@ -151,7 +152,11 @@ module Rswag
         end
 
         it "adds to the 'response examples' metadata" do
-          expect(api_metadata[:response][:examples]).to eq(json_example)
+          expect(api_metadata[:response][:content]).to match(
+            mime => {
+              example: json_example[mime]
+            }
+          )
         end
       end
     end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -235,16 +235,14 @@
                 "type": "string"
               }
             },
-            "examples": {
-              "application/json": {
-                "id": 1,
-                "title": "Hello world!",
-                "content": "Hello world and hello universe. Thank you all very much!!!",
-                "thumbnail": "thumbnail.png"
-              }
-            },
             "content": {
               "application/json": {
+                "example": {
+                  "id": 1,
+                  "title": "Hello world!",
+                  "content": "Hello world and hello universe. Thank you all very much!!!",
+                  "thumbnail": "thumbnail.png"
+                },
                 "schema": {
                   "$ref": "#/definitions/blog"
                 }


### PR DESCRIPTION
Via https://github.com/rswag/rswag/pull/330

Seems like the current version of gem generates structure irrelevant to the 3.0 API. As a result, any response examples (dynamic or static) are not being shown on UI.

PR resolves rswag/rswag#325
