### PR TITLE
Ensure `nullable` works for allOf, anyOf etc.

### DIFF
--- a/rswag-specs/lib/rswag/specs/extended_schema.rb
+++ b/rswag-specs/lib/rswag/specs/extended_schema.rb
@@ -7,14 +7,11 @@ module Rswag
     class ExtendedSchema < JSON::Schema::Draft4
       def initialize
         super
-        @attributes['type'] = ExtendedTypeAttribute
         @uri = URI.parse('http://tempuri.org/rswag/specs/extended_schema')
         @names = ['http://tempuri.org/rswag/specs/extended_schema']
       end
-    end
 
-    class ExtendedTypeAttribute < JSON::Schema::TypeV4Attribute
-      def self.validate(current_schema, data, fragments, processor, validator, options = {})
+      def validate(current_schema, data, *)
         return if data.nil? && (current_schema.schema['nullable'] == true || current_schema.schema['x-nullable'] == true)
 
         super


### PR DESCRIPTION
via https://github.com/rswag/rswag/pull/332

Previously the `nullable` check was only being applied to the `type`
attribute validation, but schemas using `anyOf`, `allOf`, `oneOf` etc
were unable to use `nullable` because they would never be passed
directly to the field validator. This is crucial when using `$ref`
combined with `nullable`, because these cases require the use of
`allOf`.

The solution here is to simplify the validation extension at the root
and not to attach the `nullable` handling to any particular attribute.

Before this change, the following would fail validation if `foo` was
`null`:

```
{
  "type": "object",
  "properties": {
    "foo": {
      "nullable": true,
      "allOf": [
        {
          "$ref": "#/components/schemas/Foo"
        }
      ]
    }
  }
}
```

With this change the `nullable` check is handled at the right spot
before the `allOf` is evaluated.