### PR TITLE
[Feature] Add requestBody.required flag

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -59,6 +59,7 @@ module Rswag
                   mime_list = value.dig(:consumes)
                   if value && schema_param && mime_list
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
+                    value[:requestBody][:required] = true if schema_param[:required]
                     mime_list.each do |mime|
                       value[:requestBody][:content][mime] = { schema: schema_param[:schema] }
                     end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -294,7 +294,8 @@
                 "type": "file"
               }
             }
-          }
+          },
+          "required": true
         }
       }
     }


### PR DESCRIPTION
via https://github.com/rswag/rswag/pull/342

## Context
* Addresses #341
* Adds the ability for users to set [the requestBody](https://swagger.io/docs/specification/describing-request-body/) as required for endpoints that consumer either a `body` or `formData`

## Usage
```ruby
parameters name: :item, in: :body, required: true, schema: { '$ref' => '#/components/schemas/item' }
```
